### PR TITLE
Update syrf-location version to fix crash on Android API level < 30

### DIFF
--- a/react-native-syrf-client/android/build.gradle
+++ b/react-native-syrf-client/android/build.gradle
@@ -134,7 +134,7 @@ dependencies {
   implementation 'androidx.appcompat:appcompat:1.4.1'
   implementation 'com.google.android.material:material:1.5.0'
 
-  implementation 'io.syrf:syrf-location:1.0.14'
+  implementation 'io.syrf:syrf-location:1.0.15'
   implementation 'io.syrf:syrf-device-info:1.0.0'
   implementation 'io.syrf:syrf-geospatial:1.0.7'
   implementation 'io.syrf:syrf-time:1.0.4'


### PR DESCRIPTION
Update syrf-location version to fix crash on Android API level < 30